### PR TITLE
Natural language dates listener fix (Closes #26)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "autotag",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "autotag",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "hasInstallScript": true,
       "dependencies": {
         "arrive": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autotag",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,8 +140,8 @@ function onload({ extensionAPI }: OnloadArgs) {
           type: "switch",
           onChange: (e) =>
             e.target.checked
-              ? document.addEventListener("keydown", dateTagListener)
-              : document.removeEventListener("keydown", dateTagListener),
+              ? document.addEventListener("keyup", dateTagListener)
+              : document.removeEventListener("keyup", dateTagListener),
         },
       },
       {


### PR DESCRIPTION
match ln 344 and 360 to remove correct listener

https://github.com/RoamJS/autotag/blob/ef97800d20237bc7f477bc63a9eab16906066f1f/src/index.ts#L344
https://github.com/RoamJS/autotag/blob/ef97800d20237bc7f477bc63a9eab16906066f1f/src/index.ts#L360