### PR TITLE
Escape plus in get replacer

### DIFF
--- a/src/page-synonyms.ts
+++ b/src/page-synonyms.ts
@@ -1,4 +1,3 @@
-import "roamjs-components/types";
 import { OnloadArgs } from "roamjs-components/types";
 import getUidsFromId from "roamjs-components/dom/getUidsFromId";
 import getUids from "roamjs-components/dom/getUids";

--- a/src/page-synonyms.ts
+++ b/src/page-synonyms.ts
@@ -65,6 +65,7 @@ const getReplacer = (extensionAPI: OnloadArgs["extensionAPI"]) => {
       .reduce((prevText: string, alias: string) => {
         const regex = new RegExp(
           `(^|[^a-zA-Z0-9_\\[\\].#])${alias
+            .replace(/\+/g, "\\+")
             .replace(/\[/g, "\\[")
             .replace(/\]/g, "\\]")}([^a-zA-Z0-9_\\[\\]]|$)`,
           "g"

--- a/src/page-synonyms.ts
+++ b/src/page-synonyms.ts
@@ -59,17 +59,21 @@ const getReplacer = (extensionAPI: OnloadArgs["extensionAPI"]) => {
     p.aliases.forEach((a: string) => (linkByAlias[a] = link));
     linkByAlias[p.title] = link;
   });
+
+  const boundaryStart = "(^|[^a-zA-Z0-9_\\[\\].#])"; // Start boundary: matches start of line or non-word, non-markup characters
+  const boundaryEnd = "([^a-zA-Z0-9_\\[\\]]|$)"; // End boundary: matches end of line or non-word, non-markup characters
+  const negativeLookahead = "(?![^\\[]*\\])"; // Negative lookahead: to not replace if already in a link
   return (input: string) =>
     Object.keys(linkByAlias)
       .sort((a, b) => b.length - a.length)
       .reduce((prevText: string, alias: string) => {
-        const regex = new RegExp(
-          `(^|[^a-zA-Z0-9_\\[\\].#])${alias
-            .replace(/\+/g, "\\+")
-            .replace(/\[/g, "\\[")
-            .replace(/\]/g, "\\]")}([^a-zA-Z0-9_\\[\\]]|$)`,
-          "g"
-        );
+        const escapedAlias = alias
+          .replace(/\+/g, "\\+")
+          .replace(/\[/g, "\\[")
+          .replace(/\]/g, "\\]");
+        const regexPattern = `${boundaryStart}${escapedAlias}${boundaryEnd}${negativeLookahead}`;
+        const regex = new RegExp(regexPattern, "g");
+
         return prevText.replace(regex, (match) =>
           match.replace(alias, `[${alias}](${linkByAlias[alias]})`)
         );


### PR DESCRIPTION
Pages with `+` in the title caused the regex to error.

https://www.loom.com/share/a7b1825d49d949189d6260db81b653b6

Reported by Josh S in [slack](https://roamresearch.slack.com/archives/C016N2B66JU/p1702827200814039)

![image](https://github.com/RoamJS/autotag/assets/3792666/54fedf37-6aba-4d5d-a2b0-e543112c94b8)
